### PR TITLE
Migrate to ppxlib

### DIFF
--- a/lens.opam
+++ b/lens.opam
@@ -12,8 +12,7 @@ build: [
 depends: [
   "ocaml"           {>= "4.10"}
   "ppx_deriving"
-  "ppx_tools"       {build}
-  "ppxfind"         {build}
+  "ppxlib"          {build}
   "dune"            {>= "1.0"}
   "ounit"           {with-test}
 ]

--- a/src/dune
+++ b/src/dune
@@ -10,8 +10,7 @@
  (synopsis "[@@deriving lens]")
  (libraries ppx_deriving.api)
  (preprocess
-  (action
-   (run ppxfind -legacy ppx_tools.metaquot --as-pp %{input-file})))
+  (pps ppxlib.metaquot))
  (ppx_runtime_libraries lens)
  (modules ppx_deriving_lens)
  (kind ppx_deriver))

--- a/src/ppx_deriving_lens.ml
+++ b/src/ppx_deriving_lens.ml
@@ -1,9 +1,8 @@
-open Longident
-open Location
-open Asttypes
-open Parsetree
-open Ast_helper
-open Ast_convenience
+open Ppxlib.Longident
+open Ppxlib.Asttypes
+open Ppxlib.Parsetree
+open Ppxlib.Ast_helper
+open Ppx_deriving.Ast_convenience
 
 let deriver = "lens"
 let raise_errorf = Ppx_deriving.raise_errorf


### PR DESCRIPTION
This pr to migrate to ppxlib and make maintainance easier.
See also ocaml-ppx/ppx_deriving#206.